### PR TITLE
Allow use of an existsing effective_tld_names.dat

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -22,6 +22,7 @@ my $builder = Module::Build->new(
 );
 
 my $dat_file = "effective_tld_names.dat";
+my $system_dat_file = $builder->config('system_publicsuffix_list');
 my $get_new_list = $builder->y_n(
     "Check for a new version of the Public Suffix List?", "N"
 );
@@ -55,7 +56,13 @@ my $rules = join " ", map {
 } IO::File->new($dat_file)->getlines;
 
 tie my @pm, "Tie::File", "lib/Mozilla/PublicSuffix.pm";
-for (@pm) { s/(my %rules = qw\()\)/$1$rules)/ and last }
+for (@pm) {
+	if ($system_dat_file) {
+		s/(my %rules = qw\(\);)/$1\n_parse_file(\\%rules,\"$system_dat_file\");/ and last
+	} else {
+		s/(my %rules = qw\()\)/$1$rules)/ and last
+	}
+}
 untie @pm;
 
 $builder->create_build_script;

--- a/lib/Mozilla/PublicSuffix.pm
+++ b/lib/Mozilla/PublicSuffix.pm
@@ -93,4 +93,17 @@ sub _find_rule {
     }
 }
 
+sub _parse_file {
+    my $rulesref = shift;
+    my $dat_file = shift;
+    open DAT ,"<:encoding(UTF-8)", "$dat_file";
+    foreach (<DAT>) {
+        s/\s//g;
+        if    ( s/^!// )        { $rulesref->{$_} = "e" }  # exception rule
+        elsif ( s/^\*\.// )     { $rulesref->{$_} = "w" }  # wildcard rule
+        elsif ( /^[\p{Word}]/ ) { $rulesref->{$_} = "i" }  # identity rule
+    }
+    close DAT;
+}
+
 1;


### PR DESCRIPTION
This is my crude attempt to allow the code to use an already existing effective_tld_names.dat

The idea is to have a systemwide copy of the list that is updated separately and make the Mozilla-PublicSuffix  use that every time instead of having the list built in.

Admittedly the approach is a bit ugly.