### PR TITLE
Change base URL for public suffix list

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -28,7 +28,7 @@ my $get_new_list = $builder->y_n(
 if ($get_new_list) {
     my $http = HTTP::Tiny->new( timeout => 6 );
     my $list_uri = URI->new(
-        "http://mxr.mozilla.org/mozilla-central/source/netwerk/dns/$dat_file"
+        "https://publicsuffix.org/list/$dat_file"
     );
     $list_uri->query_form({ raw => 1 });
     my %options = (


### PR DESCRIPTION
The URL currently in Build.PL (http://mxr.mozilla.org/mozilla-central/source/netwerk/dns/effective_tld_names.dat) now returns a 301 redirect to https://publicsuffix.org/list/effective_tld_names.dat - the code checks for a response of 200 and so causes Build.PL to croak and not produce a valid build